### PR TITLE
Tweak LzmaEnc.c to compile on recent gcc with -Werror=dangling-pointer=

### DIFF
--- a/lzma1900.diff
+++ b/lzma1900.diff
@@ -185,16 +185,22 @@ index 46a0db00..031caa7c 100644
  {
    CLzmaEnc *p = (CLzmaEnc *)pp;
    UInt64 nowPos64;
-@@ -2830,7 +2853,7 @@ SRes LzmaEnc_CodeOneMemBlock(CLzmaEncHandle pp, BoolInt reInit,
+@@ -2826,11 +2849,12 @@ SRes LzmaEnc_CodeOneMemBlock(CLzmaEncHandle pp, BoolInt reInit,
+   nowPos64 = p->nowPos64;
+   RangeEnc_Init(&p->rc);
+-  p->rc.outStream = &outStream.vt;
+
    if (desiredPackSize == 0)
      return SZ_ERROR_OUTPUT_EOF;
  
 -  res = LzmaEnc_CodeOneBlock(p, desiredPackSize, *unpackSize);
++  p->rc.outStream = &outStream.vt;
 +  res = LzmaEnc_CodeOneBlock(p, desiredPackSize, *unpackSize, bytesToSkip);
++  p->rc.outStream = 0;
    
    *unpackSize = (UInt32)(p->nowPos64 - nowPos64);
    *destLen -= outStream.rem;
-@@ -2853,7 +2876,7 @@ static SRes LzmaEnc_Encode2(CLzmaEnc *p, ICompressProgress *progress)
+@@ -2853,7 +2877,7 @@ static SRes LzmaEnc_Encode2(CLzmaEnc *p, ICompressProgress *progress)
  
    for (;;)
    {


### PR DESCRIPTION
By default, `cmake` builds makefiles that compile with `-Wall -Werror` and the code as it is fails to compile with:

```
/src/lzmaSDK-prefix/src/lzmaSDK/C/LzmaEnc.c: In function 'LzmaEnc_CodeOneMemBlock':
/src/lzmaSDK-prefix/src/lzmaSDK/C/LzmaEnc.c:2851:19: error: storing the address of local variable 'outStream' in 'p_16->rc.outStream' [-Werror=dangling-pointer=]
 2851 |   p->rc.outStream = &outStream.vt;
      |   ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
/src/lzmaSDK-prefix/src/lzmaSDK/C/LzmaEnc.c:2834:28: note: 'outStream' declared here
 2834 |   CLzmaEnc_SeqOutStreamBuf outStream;
      |                            ^~~~~~~~~
/src/lzmaSDK-prefix/src/lzmaSDK/C/LzmaEnc.c:2834:28: note: 'pp_15(D)' declared here
cc1: all warnings being treated as errors
make[3]: *** [lzmadiff/CMakeFiles/lzmasdk_obj.dir/build.make:173: lzmadiff/CMakeFiles/lzmasdk_obj.dir/__/lzmaSDK-prefix/src/lzmaSDK/C/LzmaEnc.c.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:194: lzmadiff/CMakeFiles/lzmasdk_obj.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:228: lzmadiff/CMakeFiles/lzmadiff.dir/rule] Error 2
make: *** [Makefile:233: lzmadiff] Error 2
```

This change lets it compile cleanly.